### PR TITLE
I want to lock global_mrb

### DIFF
--- a/.travis-spec-build_config.rb
+++ b/.travis-spec-build_config.rb
@@ -16,6 +16,7 @@ MRuby::Build.new do |conf|
   conf.gem :mgem => "mruby-io"
   conf.gem "../mruby-signal"
   conf.gem :mgem => "mruby-thread"
+  conf.gem :mgem => "mruby-mutex"
   conf.gem :mgem => "mruby-file-stat"
   conf.gem :mgem => "mruby-process"
   conf.gem :mgem => "mruby-at_exit"

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -1,4 +1,5 @@
 MRuby::Gem::Specification.new('mruby-signal') do |spec|
   spec.license = 'MIT'
   spec.author  = 'ksss <co000ri@gmail.com>'
+  spec.add_dependency 'mruby-mutex'
 end

--- a/mrblib/signal.rb
+++ b/mrblib/signal.rb
@@ -1,0 +1,17 @@
+module Signal
+  def self.mutex
+    @m ||= Mutex.new
+  end
+
+  def self.mrb_state_lock
+    mutex.lock
+    self.lock
+    mutex.unlock
+  end
+
+  def self.mrb_state_unlock
+    mutex.lock
+    self.unlock
+    mutex.unlock
+  end
+end


### PR DESCRIPTION
Hi!
We implemented it because we want to lock global_mrb when using it with multithreading.
https://github.com/ksss/mruby-signal/blob/master/src/signal.c#L558
↑ code is executed at mrb_open to prevent global_mrb from being rewritten.

- sample.rb
```ruby
def run_with_signal msec_timer, signal
  @timer_thread = Thread.new msec_timer, 1000, signal do |timer, interval, sig|
    loop_time = 0
    # calculate by usec
    while loop_time < timer * 1000
      loop_time += usleep interval
    end
    Process.kill sig, Process.pid
  end
  Signal.mrb_state_unlock
end

Signal.trap(:USR1) do |signo|
  puts "catch signal from timer thread"
  exit
end
Signal.mrb_state_lock

run_with_signal 1000, :USR1

puts "waiting timer"
loop { sleep 1 }
```