### PR TITLE
An attempt at supporting multiple virtual machines

### DIFF
--- a/src/signal.c
+++ b/src/signal.c
@@ -452,10 +452,9 @@ signal_trap(mrb_state *mrb, mrb_value mod)
   sighandler_t func;
   struct RClass *mrb_mSignal;
 
-  if (mruby_signal_mrb != mrb) 
-    mrb_raisef(mrb, E_ARGUMENT_ERROR, "NOOOOO NOOO NOOO i mrb son diversi!!!!!!!!!!!!!!!!!!!!");
+  if (mruby_signal_mrb!=mrb) 
+    mrb_raise(mrb,E_TYPE_ERROR,"A different MRB has been passed.");
     /* multi mrb_state doesn't supported yet */
-  
 
   mrb_get_args(mrb, "*&", &argv, &argc, &block);
   if (argc != 1 && argc != 2)

--- a/src/signal.c
+++ b/src/signal.c
@@ -442,7 +442,6 @@ trap(mrb_state *mrb, mrb_value mod, int sig, sighandler_t func, mrb_value comman
   return oldcmd;
 }
 
-
 static mrb_value
 signal_trap(mrb_state *mrb, mrb_value mod)
 {
@@ -453,10 +452,10 @@ signal_trap(mrb_state *mrb, mrb_value mod)
   sighandler_t func;
   struct RClass *mrb_mSignal;
 
-  if (mruby_signal_mrb != mrb) {
+  if (mruby_signal_mrb != mrb) 
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "NOOOOO NOOO NOOO i mrb son diversi!!!!!!!!!!!!!!!!!!!!");
     /* multi mrb_state doesn't supported yet */
-    return mrb_nil_value();
-  }
+  
 
   mrb_get_args(mrb, "*&", &argv, &argc, &block);
   if (argc != 1 && argc != 2)
@@ -550,6 +549,32 @@ install_sighandler(mrb_state *mrb, int signum, sighandler_t handler)
 #  define install_sighandler(mrb, signum, handler) (install_sighandler(mrb, signum, handler) ? mrb_bug(mrb, #signum) : (void)0)
 #endif
 
+mrb_value mrb_mruby_signal_handler_reset(mrb_state *mrb,mrb_value self)
+{
+  mruby_signal_mrb=mrb;
+  install_sighandler(mrb,SIGINT,sighandler);
+#ifdef SIGHUP
+  install_sighandler(mrb,SIGHUP,sighandler);
+#endif
+#ifdef SIGQUIT
+  install_sighandler(mrb,SIGQUIT,sighandler);
+#endif
+#ifdef SIGTERM
+  install_sighandler(mrb,SIGTERM,sighandler);
+#endif
+#ifdef SIGALRM
+  install_sighandler(mrb,SIGALRM,sighandler);
+#endif
+#ifdef SIGUSR1
+  install_sighandler(mrb,SIGUSR1,sighandler);
+#endif
+#ifdef SIGUSR2
+  install_sighandler(mrb,SIGUSR2,sighandler);
+#endif
+
+  return self;
+}
+
 void
 mrb_mruby_signal_gem_init(mrb_state* mrb) {
   struct RClass *signal = mrb_define_module(mrb, "Signal");
@@ -558,6 +583,7 @@ mrb_mruby_signal_gem_init(mrb_state* mrb) {
   mrb_define_class_method(mrb, signal, "trap", signal_trap, MRB_ARGS_ANY());
   mrb_define_class_method(mrb, signal, "list", signal_list, MRB_ARGS_NONE());
   mrb_define_class_method(mrb, signal, "signame", signal_signame, MRB_ARGS_REQ(1));
+  mrb_define_class_method(mrb,signal,"reset!",mrb_mruby_signal_handler_reset,MRB_ARGS_NONE());
 
   mrb_define_method(mrb, mrb->kernel_module, "trap", signal_trap, MRB_ARGS_ANY());
 


### PR DESCRIPTION
Hello.
I create new Mruby virtual machines from currently running ones (by invoking `mrb_open`). With mruby-signal as-is, if signals are received by the later virtual machines (with separate PIDs), they execute whatever traps are registered by the first virtual machine. 

A first change I really think is necessary is to raise an exception from within `signal_trap` if the two `mrb`'s are different. Just to return `nil` is quite confusing. 

Once I realized what was going on, I added a Ruby-callable method `mrb_mruby_signal_handler_reset`, `reset!` from Ruby's side (you can see it in my patch), that I only call once from C, right after I receive  the pointer to the new virtual machine, this way:

```c
    struct RClass *c=mrb_module_get(vm,"Signal");
    mrb_funcall(vm,mrb_obj_value(c),"reset!",0);
```

This solves my problem, but I have no idea if it may be a generalized solution (it only works when you fork a new process, I believe). I just wanted to leave a trace of what I did, in case someone comes up with similar needs as I.
