### PR TITLE
Supported real-time signal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: c
+sudo: required
 before_install:
   - sudo apt-get -qq update
 install:

--- a/test/signal.rb
+++ b/test/signal.rb
@@ -23,6 +23,8 @@ assert 'Signal#trap' do
   Signal.trap(0, "SIG_DFL")
   assert_nil Signal.trap("EXIT"){}
   assert_raise(ArgumentError){ Signal.trap -1 }
+
+  assert_nil Signal.trap(:RT1){}
 end
 
 assert "Signal#list" do
@@ -35,5 +37,8 @@ assert "Signal#signame" do
   assert_equal "HUP", Signal.signame(1)
   assert_equal "INT", Signal.signame(2)
   assert_equal "QUIT", Signal.signame(3)
+  assert_equal "RT0", Signal.signame(34)
+  assert_equal "RT30", Signal.signame(64)
+  assert_equal nil, Signal.signame(65)
   assert_equal nil, Signal.signame(-1)
 end


### PR DESCRIPTION
Hello!
Supported real-time signal.
The numbers `34` to `64` of the real-time signal were assigned from `RT1` to `RT30` .

I confirmed that it works with the following code.

- code

  ```ruby
  puts "Signal 35 = #{Signal.signame 35}"

  Signal.trap(:RT1) do
    puts "received signal"
    exit
  end

  puts "Pid = #{Process.pid}"

  loop { sleep 1 }
  ```

- result

  ```sh
  # bin/mruby signal.rb
  Signal 35 = RT1
  Pid = 21520
  # kill -35 21520
  received signal
  ```

Please check.