### PR TITLE
Support "RTMIN" and "RTMAX" for Realtime-signal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ before_script:
   - git clone https://github.com/ksss/mruby-spec.git ../mruby-spec
 script:
   - cd ../mruby-spec
+  - mkdir -p unsupported/signal
+  - echo "Signal.list doesn't contain other signals than the known list" > unsupported/signal/list.txt
   - make MRUBY_CONFIG="../../mruby-signal/.travis-spec-build_config.rb" TESTS="core/signal core/exception/interrupt_spec.rb core/exception/signal_exception_spec.rb"
   - cd mruby
   - make test MRUBY_CONFIG="../../mruby-signal/.travis-test-build_config.rb"

--- a/src/signal.c
+++ b/src/signal.c
@@ -483,6 +483,12 @@ signal_list(mrb_state *mrb, mrb_value mod)
   for (sigs = siglist; sigs->signm; sigs++) {
     mrb_hash_set(mrb, h, mrb_str_new_cstr(mrb, sigs->signm), mrb_fixnum_value(sigs->signo));
   }
+#ifdef SIGRTMIN
+  mrb_hash_set(mrb, h, mrb_str_new_lit(mrb, "RTMIN"), mrb_fixnum_value(SIGRTMIN));
+#endif
+#ifdef SIGRTMAX
+  mrb_hash_set(mrb, h, mrb_str_new_lit(mrb, "RTMAX"), mrb_fixnum_value(SIGRTMAX));
+#endif
   return h;
 }
 


### PR DESCRIPTION
**This is an EXPERIMENTALLY implementation.**
This patch make realtime-signal more portable.

Use case:

```rb
unless Signal.list["RTMIN"]
  raise "realtime-signal does not supported"
end

MY_SIGNAL = Signal.list["RTMIN"] + 1

Signal.trap(MY_SIGNAL) do |i|
  puts "Hello MY_SIGNAL"
end

Process.kill(MY_SIGNAL, $$)
#=> "Hello MY_SIGNAL"
```

ref: https://bugs.ruby-lang.org/issues/13639